### PR TITLE
Make `new` overridable.

### DIFF
--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -116,6 +116,8 @@ defmodule ExConstructor do
           Keyword.merge(@exconstructor_default_options, opts)
         )
       end
+
+      defoverridable [{unquote(constructor_name), 2}]
     end
   end
 

--- a/test/exconstructor_test.exs
+++ b/test/exconstructor_test.exs
@@ -187,5 +187,22 @@ defmodule ExConstructorTest do
     end
   end
 
+  describe "overriding" do
+    defmodule TestStructOverrideNew do
+      defstruct [:name]
+      use ExConstructor
+
+      def new(data, args) do
+        res = super(data, args)
+        %{res | name: String.capitalize(res.name)}
+      end
+    end
+
+    test "can override new and call super" do
+      ts_map = TestStructOverrideNew.new(%{"name" => "jim"})
+      assert("Jim" == ts_map.name)
+    end
+  end
+
 end
 


### PR DESCRIPTION
The documentation for exconstructor suggests that you can override the
new function in modules that use ExConstructor.  This might be the case,
but without marking them with `defoverridable` we can't use `super` to
easily call into the original new function.

The case where I've found this useful is for nested structs - I have a
struct that contains a list of other structs, and I'd like to have my
new call convert all the members of the list as well.
