### PR TITLE
parse acronyms for strings with both upper camelcase and regularcase

### DIFF
--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -61,7 +61,8 @@ defmodule ExConstructor do
     defstruct strings: true,
               atoms: true,
               camelcase: true,
-              underscore: true
+              underscore: true,
+              acronyms: true
   end
 
 
@@ -163,6 +164,8 @@ defmodule ExConstructor do
           Map.get(map, under_str)
         Map.has_key?(map, under_atom) and opts.atoms and opts.underscore ->
           Map.get(map, under_atom)
+        has_acronym?(map, str) and opts.strings and opts.acronyms ->
+          get_acryonym(map, str)
         Map.has_key?(map, camel_str) and opts.strings and opts.camelcase ->
           Map.get(map, camel_str)
         Map.has_key?(map, camel_atom) and opts.atoms and opts.camelcase ->
@@ -209,6 +212,44 @@ defmodule ExConstructor do
     first = String.slice(str, 0..0) |> String.downcase
     first <> String.slice(str, 1..-1)
   end
+
+    def all_acronyms(str) do
+    Enum.concat(acronyms(str), acronyms_with_camel_case(str))
+    |> Enum.uniq()
+  end
+
+  def acronyms(str) do
+    words = String.split(str, "_")
+    count = Enum.count(words)
+    words
+    |> List.duplicate(count)
+    |> Enum.with_index(1)
+    |> Enum.map(
+      fn({words_list, outer_index}) ->
+        Enum.with_index(words_list, 1)
+        |> Enum.map(
+          fn({word, inner_index}) -> if outer_index == inner_index, do: String.upcase(word), else: word end
+        )
+      end
+    )
+    |> Enum.map(&Enum.join/1)
+  end
+
+  def acronyms_with_camel_case(str) do
+    words = String.split(str, "_")
+    |> Enum.map(&String.capitalize/1)
+    |> Enum.join()
+    |> acronyms()
+  end
+
+  defp has_acronym?(map, str) do
+    all_acronyms(str) |> Enum.any?(fn(str) -> Map.has_key?(map, str) end )
+  end
+
+  defp get_acryonym(map, str) do
+    all_acronyms(str) |> Enum.find(fn(str) -> Map.has_key?(map, str) end )
+  end
+
 
 end
 


### PR DESCRIPTION
- Attempts to solve the problem outlined in [issue 10](https://github.com/appcues/exconstructor/issues/10)
- I tried to add tests but couldn't figure them out... Please can you/someone take a look at adding tests for this feature 

``` elixir
  defmodule Identity.Endpoint do
    defstruct [:admin_url, :region, :internal_url, :id, :public_url]
    use ExConstructor
  end
```

``` elixir
Identity.Endpoint.new(
  %{
  "adminURL" => "adminURL", 
  "id" => "id", 
  "internalURL" => "internalURL", 
  "publicURL" => "publicURL",
   "region" => "region"
  }
)
```
#### Before

Returns

``` elixir
%Identity.Endpoint{
  admin_url: nil, 
  id: "id", 
  internal_url: nil, 
  public_url: nil,
  region: "region"
}
```
#### After

Returns

``` elixir
%Identity.Endpoint{
  admin_url: "adminURL", 
  id: "id",
 internal_url: "internalURL", 
 public_url: "publicURL", 
 region: "region"
}
```
