### PR TITLE
parse acronyms

### DIFF
--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -242,7 +242,7 @@ defmodule ExConstructor do
   defp acronyms_with_camel_case(str) do
     words = String.split(str, "_")
     |> Enum.map(&String.capitalize/1)
-    |> Enum.join()
+    |> Enum.join("_")
     |> acronyms()
   end
 

--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -61,7 +61,8 @@ defmodule ExConstructor do
     defstruct strings: true,
               atoms: true,
               camelcase: true,
-              underscore: true
+              underscore: true,
+              acronyms: true
   end
 
 
@@ -164,6 +165,8 @@ defmodule ExConstructor do
           Map.get(map, under_str)
         Map.has_key?(map, under_atom) and opts.atoms and opts.underscore ->
           Map.get(map, under_atom)
+        has_acronym?(map, str) and opts.strings and opts.acronyms ->
+          Map.get(map, get_acryonym(map, str))
         Map.has_key?(map, up_camel_str) and opts.strings and opts.camelcase ->
           Map.get(map, up_camel_str)
         Map.has_key?(map, camel_str) and opts.strings and opts.camelcase ->
@@ -212,5 +215,44 @@ defmodule ExConstructor do
     first = String.slice(str, 0..0) |> String.downcase
     first <> String.slice(str, 1..-1)
   end
+
+
+  defp all_acronyms(str) do
+    Enum.concat(acronyms(str), acronyms_with_camel_case(str))
+    |> Enum.uniq()
+  end
+
+  defp acronyms(str) do
+    words = String.split(str, "_")
+    count = Enum.count(words)
+    words
+    |> List.duplicate(count)
+    |> Enum.with_index(1)
+    |> Enum.map(
+      fn({words_list, outer_index}) ->
+        Enum.with_index(words_list, 1)
+        |> Enum.map(
+          fn({word, inner_index}) -> if outer_index == inner_index, do: String.upcase(word), else: word end
+        )
+      end
+    )
+    |> Enum.map(&Enum.join/1)
+  end
+
+  defp acronyms_with_camel_case(str) do
+    words = String.split(str, "_")
+    |> Enum.map(&String.capitalize/1)
+    |> Enum.join()
+    |> acronyms()
+  end
+
+  defp has_acronym?(map, str) do
+    all_acronyms(str) |> Enum.any?(fn(new_str) -> Map.has_key?(map, new_str) end )
+  end
+
+  defp get_acryonym(map, str) do
+    all_acronyms(str) |> Enum.find(fn(new_str) -> Map.has_key?(map, new_str) end )
+  end
+
 
 end

--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -240,7 +240,7 @@ defmodule ExConstructor do
   end
 
   defp acronyms_with_camel_case(str) do
-    words = String.split(str, "_")
+    String.split(str, "_")
     |> Enum.map(&String.capitalize/1)
     |> Enum.join("_")
     |> acronyms()

--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -151,6 +151,7 @@ defmodule ExConstructor do
     Enum.reduce keys, struct, fn (atom, acc) ->
       str = to_string(atom)
       under_str = Macro.underscore(str)
+      up_camel_str = Macro.camelize(str)
       camel_str = Macro.camelize(str) |> lcfirst
       under_atom = String.to_atom(under_str)
       camel_atom = String.to_atom(camel_str)
@@ -163,6 +164,8 @@ defmodule ExConstructor do
           Map.get(map, under_str)
         Map.has_key?(map, under_atom) and opts.atoms and opts.underscore ->
           Map.get(map, under_atom)
+        Map.has_key?(map, up_camel_str) and opts.strings and opts.camelcase ->
+          Map.get(map, up_camel_str)
         Map.has_key?(map, camel_str) and opts.strings and opts.camelcase ->
           Map.get(map, camel_str)
         Map.has_key?(map, camel_atom) and opts.atoms and opts.camelcase ->
@@ -211,4 +214,3 @@ defmodule ExConstructor do
   end
 
 end
-

--- a/test/exconstructor_test.exs
+++ b/test/exconstructor_test.exs
@@ -10,7 +10,8 @@ defmodule ExConstructorTest do
               field_five: 5,
               Field_Six: 6,
               FieldSeven: 7,
-              FieldEight: 8
+              FieldEight: 8,
+              field_nine: 9
     use ExConstructor
   end
 
@@ -20,10 +21,10 @@ defmodule ExConstructorTest do
     it "handles maps with string-vs-atom, camel-vs-underscore, and literals" do
       map = %{"field_one" => "a", "fieldTwo" => "b", :field_three => "c",
               :fieldFour => "d", "Field_Six" => "f", "field_seven" => 7,
-              :field_eight => 8}
+              :field_eight => 8, "FieldNine" => "Nine"}
       struct = %TestStruct{field_one: "a", field_two: "b", field_three: "c",
                            field_four: "d", field_five: 5, Field_Six: "f",
-                           FieldSeven: 7, FieldEight: 8}
+                           FieldSeven: 7, FieldEight: 8, field_nine: "Nine"}
       assert(struct == populate_struct(%TestStruct{}, map, []))
     end
 
@@ -31,7 +32,7 @@ defmodule ExConstructorTest do
       kwlist = [{:field_one, "a"}, {"field_two", "b"}]
       struct = %TestStruct{field_one: "a", field_two: "b", field_three: 3,
                            field_four: 4, field_five: 5, Field_Six: 6,
-                           FieldSeven: 7, FieldEight: 8}
+                           FieldSeven: 7, FieldEight: 8, field_nine: 9}
       assert(struct == populate_struct(%TestStruct{}, kwlist, []))
     end
 
@@ -205,4 +206,3 @@ defmodule ExConstructorTest do
   end
 
 end
-

--- a/test/exconstructor_test.exs
+++ b/test/exconstructor_test.exs
@@ -11,7 +11,8 @@ defmodule ExConstructorTest do
               Field_Six: 6,
               FieldSeven: 7,
               FieldEight: 8,
-              field_nine: 9
+              field_nine: 9,
+              field_ten: 10
     use ExConstructor
   end
 
@@ -21,10 +22,10 @@ defmodule ExConstructorTest do
     it "handles maps with string-vs-atom, camel-vs-underscore, and literals" do
       map = %{"field_one" => "a", "fieldTwo" => "b", :field_three => "c",
               :fieldFour => "d", "Field_Six" => "f", "field_seven" => 7,
-              :field_eight => 8, "FieldNine" => "Nine"}
+              :field_eight => 8, "FieldNine" => "Nine", "FieldTen": 10}
       struct = %TestStruct{field_one: "a", field_two: "b", field_three: "c",
                            field_four: "d", field_five: 5, Field_Six: "f",
-                           FieldSeven: 7, FieldEight: 8, field_nine: "Nine"}
+                           FieldSeven: 7, FieldEight: 8, field_nine: "Nine", field_ten: 10}
       assert(struct == populate_struct(%TestStruct{}, map, []))
     end
 
@@ -32,7 +33,7 @@ defmodule ExConstructorTest do
       kwlist = [{:field_one, "a"}, {"field_two", "b"}]
       struct = %TestStruct{field_one: "a", field_two: "b", field_three: 3,
                            field_four: 4, field_five: 5, Field_Six: 6,
-                           FieldSeven: 7, FieldEight: 8, field_nine: 9}
+                           FieldSeven: 7, FieldEight: 8, field_nine: 9, field_ten: 10}
       assert(struct == populate_struct(%TestStruct{}, kwlist, []))
     end
 


### PR DESCRIPTION
- Attempts to solve the problem outlined in [issue 10](https://github.com/appcues/exconstructor/issues/10)

``` elixir
  defmodule Identity.Endpoint do
    defstruct [:admin_url, :region, :internal_url, :id, :public_url]
    use ExConstructor
  end
```

``` elixir
Identity.Endpoint.new(
  %{
  "adminURL" => "adURL", 
  "id" => "id", 
  "internalURL" => "intlURL", 
  "publicURL" => "pubURL",
   "region" => "region"
  }
)
```
#### Before PR

Returns

``` elixir
%Identity.Endpoint{
  admin_url: nil, 
  id: "id", 
  internal_url: nil, 
  public_url: nil,
  region: "region"
}
```
#### After PR

Returns

``` elixir
%Identity.Endpoint{
  admin_url: "adURL", 
  id: "id",
 internal_url: "intURL", 
 public_url: "pubURL", 
 region: "region"
}
```
