### PR TITLE
Don't crash if @enforce_keys exists

### DIFF
--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -113,7 +113,7 @@ defmodule ExConstructor do
       @spec unquote(constructor_name)(ExConstructor.map_or_kwlist, Keyword.t) :: %__MODULE__{}
       def unquote(constructor_name)(map_or_kwlist, opts \\ []) do
         ExConstructor.populate_struct(
-          %__MODULE__{},
+          struct(__MODULE__, []),
           map_or_kwlist,
           Keyword.merge(@exconstructor_default_options, opts)
         )

--- a/test/exconstructor_test.exs
+++ b/test/exconstructor_test.exs
@@ -128,6 +128,14 @@ defmodule ExConstructorTest do
       end)
       assert(String.match?(ex.message, ~r"^argument must be"))
     end
+
+    it "does not crash if @enforce_keys exists" do
+      defmodule TestStruct7 do
+        @enforce_keys :field
+        defstruct field: 1
+        use ExConstructor
+      end
+    end
   end
 
 


### PR DESCRIPTION
Closes #21 

This is a quick fix because it is rather annoying (for [my library](https://github.com/dylan-chong/ex_structable)). 

now the behaviour will be to completely ignore @enforce_keys. I dont expect that to be a competely straightforward change so I would like this quick fix. Actual fix can be discussed in #22