### PR TITLE
Fix typespec for populate_struct/2

### DIFF
--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -136,7 +136,7 @@ defmodule ExConstructor do
   Set these keys false to prevent testing of that key format in
   `map_or_kwlist`.  All default to `true`.
   """
-  @spec populate_struct(struct, map_or_kwlist, %Options{}) :: struct
+  @spec populate_struct(struct, map_or_kwlist, %Options{} | map_or_kwlist) :: struct
   def populate_struct(struct, map_or_kwlist, %Options{} = opts) do
     map =
       cond do


### PR DESCRIPTION
When I did the cleanup in #27 I removed a typespec:
https://github.com/appcues/exconstructor/pull/27/files#diff-9d740b81ce2e444f305074e30bf031039b97d234ac866fa5b329f46902052d6fL182

This was because having multiple typespecs for a given function is
ignored:

```
Overloaded contract for ExConstructor.populate_struct/3 has
overlapping domains; such contracts are currently unsupported and
are simply ignored.
```

Removing that bit, while correct, made the remaining typespec for
populate_struct/3 *wrong*, as the options argument can also be
`map_or_kwlist`, so I changed the type signature to be correct there.