### PR TITLE
Fix warning when used in elixir 1.16

### DIFF
--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -225,6 +225,6 @@ defmodule ExConstructor do
   @spec lcfirst(String.t()) :: String.t()
   defp lcfirst(str) do
     first = String.slice(str, 0..0) |> String.downcase()
-    first <> String.slice(str, 1..-1)
+    first <> String.slice(str, 1..-1//1)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ExConstructor.Mixfile do
       version: "1.2.11",
       description: description(),
       package: package(),
-      elixir: "~> 1.2",
+      elixir: "~> 1.12",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       docs: [main: ExConstructor],


### PR DESCRIPTION
Elixir 1.16.0 `String.slice/2` started warning about the range having negative steps:

```elixir
iex(1)> String.slice("demo", 1..-1)
warning: negative steps are not supported in String.slice/2, pass 1..-1//1 instead
  (elixir 1.16.0) lib/string.ex:2368: String.slice/2
  (elixir 1.16.0) src/elixir.erl:405: :elixir.eval_external_handler/3
  (stdlib 5.2) erl_eval.erl:750: :erl_eval.do_apply/7
  (elixir 1.16.0) src/elixir.erl:378: :elixir.eval_forms/4
  (elixir 1.16.0) lib/module/parallel_checker.ex:112: Module.ParallelChecker.verify/1
  (iex 1.16.0) lib/iex/evaluator.ex:331: IEx.Evaluator.eval_and_inspect/3
  (iex 1.16.0) lib/iex/evaluator.ex:305: IEx.Evaluator.eval_and_inspect_parsed/3
  (iex 1.16.0) lib/iex/evaluator.ex:294: IEx.Evaluator.parse_eval_inspect/4
  (iex 1.16.0) lib/iex/evaluator.ex:187: IEx.Evaluator.loop/1
  (iex 1.16.0) lib/iex/evaluator.ex:32: IEx.Evaluator.init/5
  (stdlib 5.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```

This fixes it.