### PR TITLE
chore: Fix elixir 1.16 warning

### DIFF
--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -225,6 +225,6 @@ defmodule ExConstructor do
   @spec lcfirst(String.t()) :: String.t()
   defp lcfirst(str) do
     first = String.slice(str, 0..0) |> String.downcase()
-    first <> String.slice(str, 1..-1)
+    first <> String.slice(str, 1..-1//1)
   end
 end


### PR DESCRIPTION
Fix the following warning when using Elixir 1.16

```shell
warning: negative steps are not supported in String.slice/2, pass 1..-1//1 instead
  (elixir 1.16.0) lib/string.ex:2368: String.slice/2
  (exconstructor 1.2.11) lib/exconstructor.ex:228: ExConstructor.lcfirst/1
  (exconstructor 1.2.11) lib/exconstructor.ex:158: anonymous fn/5 in ExConstructor.populate_struct/3
  (elixir 1.16.0) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
  test/exconstructor_test.exs:136: ExConstructorTest."test invocation styles use ExConstructor uses the default constructor name"/1
  (ex_unit 1.16.0) lib/ex_unit/runner.ex:472: ExUnit.Runner.exec_test/2
  (stdlib 5.0.2) timer.erl:270: :timer.tc/2
  (ex_unit 1.16.0) lib/ex_unit/runner.ex:394: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4

```