### PR TITLE
Fix String.slice warning in elixir 1.16

### DIFF
--- a/lib/exconstructor.ex
+++ b/lib/exconstructor.ex
@@ -225,6 +225,6 @@ defmodule ExConstructor do
   @spec lcfirst(String.t()) :: String.t()
   defp lcfirst(str) do
     first = String.slice(str, 0..0) |> String.downcase()
-    first <> String.slice(str, 1..-1)
+    first <> String.slice(str, 1..-1//1)
   end
 end


### PR DESCRIPTION
This fixes elixir 1.16 warning:
```
warning: negative steps are not supported in String.slice/2, pass 1..-1//1 instead
```