### PR TITLE
Update mix.ex application function

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ExConstructor.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do


### PR DESCRIPTION
Unable to publish deps update due to error running `mix docs`. Error seems to be due to an old `application` function in `mix.exs`. See thread here https://elixirforum.com/t/issues-running-mix-docs-undefinedfunctionerror-function-makeup-application/63707/9