### PR TITLE
Allow use ExConstructor to Be Declared Before defstruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ parts of your program.
 
 ```elixir
 defmodule TestStruct do
+  use ExConstructor
   defstruct field_one: nil,
             field_two: nil,
             field_three: nil,
             field_four: nil
-  use ExConstructor
 end
 
 TestStruct.new(%{"field_one" => "a", "fieldTwo" => "b", :field_three => "c", :FieldFour => "d"})

--- a/test/exconstructor_test.exs
+++ b/test/exconstructor_test.exs
@@ -133,26 +133,17 @@ defmodule ExConstructorTest do
       assert(nil != TestStruct2.new(%{}))
     end
 
-    # test "use ExConstructor, :constructor_name" do
     test "use ExConstructor, :constructor_name - uses the given constructor name" do
       assert(nil != TestStruct3.make(%{}))
     end
 
-    # end
-
-    # test "use ExConstructor, name: :constructor_name" do
     test "use ExConstructor, name: :constructor_name - uses the given constructor name" do
       assert(nil != TestStruct4.build(%{}))
     end
 
-    # end
-
-    # test "ExConstructor.__using__" do
     test "ExConstructor.__using__ - uses the default constructor name" do
       assert(nil != TestStruct5.new(%{}))
     end
-
-    # end
 
     test "raises exception on bad invocation" do
       ex =

--- a/test/exconstructor_test.exs
+++ b/test/exconstructor_test.exs
@@ -164,6 +164,15 @@ defmodule ExConstructorTest do
         use ExConstructor
       end
     end
+
+    defmodule TestStruct8 do
+      use ExConstructor
+      defstruct field: nil
+    end
+
+    test "use ExConstructor before defstruct - uses the default constructor name" do
+      assert(nil != TestStruct8.new(%{}))
+    end
   end
 
   describe "options" do


### PR DESCRIPTION
The requirement for `use ExConstructor` to appear after the defstruct can cause issues, such as:

- **Stylistic Conflicts**: Tools like Styler and Credo may have rules that suggest placing use directives at the top of the module, leading to unnecessary warnings or errors in codebases that adhere to such style guides.
- **Readability**: Placing the use directive at the top of a module is a more common convention in the Elixir community and improves the readability of the module's structure.

With this update, the `use ExConstructor` directive can now be placed before the defstruct.